### PR TITLE
add header includes that were forgotten

### DIFF
--- a/core/core.c
+++ b/core/core.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <time.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #define _J_BUFSIZE 128
 

--- a/core/main.c
+++ b/core/main.c
@@ -1,6 +1,7 @@
 #include "4julia.h"
 
-#include "readline/readline.h"
+#include <readline/readline.h>
+#include <readline/history.h>
 
 #include <stdio.h>
 #include <time.h>


### PR DESCRIPTION
Fixes two compiler warnings, one for an implicit declaration of sleep (unistd.h) and one for an implicit declaration of add_history (readline/history.h).